### PR TITLE
Fixing dep tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/package-lock.json
+
 node_modules/
 *sublime*
 dist/*.map

--- a/package.json
+++ b/package.json
@@ -3,31 +3,27 @@
   "version": "0.1.0",
   "description": "Orbit - Communication System on IPFS",
   "main": "src/Orbit.js",
-  "browser": {
-    "fs-pull-blob-store": "idb-pull-blob-store"
-  },
   "dependencies": {
     "ipfs-post": "~0.1.0-beta.1",
-    "logplease": "^1.2.9",
+    "logplease": "^1.2.14",
     "lru": "~3.1.0",
-    "orbit-crypto": "~0.1.0-beta.1",
-    "orbit-db": "~0.17.1"
+    "orbit-crypto": "~0.1.0-beta.2",
+    "orbit-db": "~0.17.3"
   },
   "devDependencies": {
-    "babel-core": "^6.14.0",
-    "babel-loader": "^6.2.5",
-    "babel-plugin-syntax-flow": "^6.13.0",
-    "babel-plugin-transform-flow-strip-types": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
-    "bluebird": "^3.4.6",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-plugin-syntax-flow": "^6.18.0",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
+    "bluebird": "^3.5.0",
     "fs-pull-blob-store": "^0.4.1",
     "idb-pull-blob-store": "^0.5.1",
-    "ipfs-daemon": "^0.3.0-beta.24",
-    "ipfs-test-apis": "^0.1.0-beta.4",
-    "json-loader": "^0.5.4",
-    "mocha": "^2.5.3",
-    "rimraf": "^2.5.4",
-    "webpack": "^2.1.0-beta.27"
+    "ipfs-test-apis": "^0.1.0-beta.5",
+    "json-loader": "^0.5.7",
+    "mocha": "^3.5.0",
+    "rimraf": "^2.6.1",
+    "webpack": "^3.5.5"
   },
   "scripts": {
     "test": "mocha",

--- a/src/Orbit.js
+++ b/src/Orbit.js
@@ -152,7 +152,8 @@ class Orbit {
     logger.debug(`Send message to #${channel}: ${message}`)
 
     let data = {
-      content: message.substring(0, 2048),
+      // TODO: Question for Haad, why are you truncating messages?
+      content: new Buffer(message.substring(0, 2048)),
       replyto: replyToHash || null,
       from: this.user
     }


### PR DESCRIPTION
Started doing things for https://github.com/orbitdb/orbit-web/issues/9

It seems that is really embed in the concept of Orbit that PubSub messages are passed as strings and not as Buffers.

```
 1) Orbit send sends a message to a channel:
     TypeError: "string" must be a string, Buffer, or ArrayBuffer
      at Function.byteLength (buffer.js:477:11)
      at Promise (node_modules/ipfs-post/src/Post.js:44:51)
      at Promise (<anonymous>)
      at Function.create (node_modules/ipfs-post/src/Post.js:27:12)
      at Orbit._postMessage (src/Orbit.js:373:17)
      at getUser.then.then.then (src/Orbit.js:165:28)
      at <anonymous>
```

I fixed one of these assumptions, but now found that there is an assumption in another dependency. Before I follow this 🐇, I want to make sure it is cool to refactor this things, I might have to change a lot of nits to make it all work and end up with a big refactor. 